### PR TITLE
SPD-1399 switching between smoothed data and original based on isActive

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A sweet & simple chart library for React Native that will make us feel like **W*
 
 ## Install
 
-To get started with using WAGMI charts in your React Native project, install the `react-native-wagmi-charts` package.
+To get started with using WAGMI charts in your React Native project, install the `react-native-wagmi-charts` package using Node 14.
 
 ```
 npm install react-native-wagmi-charts

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test": "jest",
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
-    "prepare": "bob build",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
     "bootstrap": "yarn example && yarn && yarn pods"
@@ -40,8 +39,7 @@
     "d3-scale": "^2",
     "d3-shape": "^3.0.1",
     "react-keyed-flatten-children": "^1.3.0",
-    "react-native-redash": "^16.1.1",
-    "smoothish": "^1.0.0"
+    "react-native-redash": "^16.1.1"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^12.0.4",
@@ -65,6 +63,7 @@
     "react-native-gesture-handler": "^2.1.0",
     "react-native-reanimated": "~2.3.1",
     "react-native-svg": "^12.1.1",
+    "smoothish": "^1.0.0",
     "typescript": "^4.3.5"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "d3-scale": "^2",
     "d3-shape": "^3.0.1",
     "react-keyed-flatten-children": "^1.3.0",
-    "react-native-redash": "^16.1.1"
+    "react-native-redash": "^16.1.1",
+    "smoothish": "^1.0.0"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^12.0.4",

--- a/src/charts/line/Chart.tsx
+++ b/src/charts/line/Chart.tsx
@@ -14,6 +14,8 @@ export const LineChartDimensionsContext = React.createContext({
   pointWidth: 0,
   parsedPath: {} as Path,
   path: '',
+  smoothedParsedPath: {} as Path,
+  smoothedPath: '',
   area: '',
   shape: d3Shape.curveBumpX,
   gutter: 0,
@@ -70,6 +72,23 @@ export function LineChart({
         shape,
         yDomain,
         xDomain,
+        isOriginalData: true,
+      });
+    }
+    return '';
+  }, [data, pathWidth, height, yGutter, shape, yDomain, xDomain]);
+
+  const smoothedPath = React.useMemo(() => {
+    if (data && data.length > 0) {
+      return getPath({
+        data,
+        width: pathWidth,
+        height,
+        gutter: yGutter,
+        shape,
+        yDomain,
+        xDomain,
+        isOriginalData: false,
       });
     }
     return '';
@@ -91,6 +110,7 @@ export function LineChart({
 
   const dataLength = data.length;
   const parsedPath = React.useMemo(() => parse(path), [path]);
+  const smoothedParsedPath = React.useMemo(() => parse(smoothedPath), [smoothedPath]);
   const pointWidth = React.useMemo(
     () => width / (dataLength - 1),
     [dataLength, width]
@@ -100,9 +120,11 @@ export function LineChart({
     () => ({
       gutter: yGutter,
       parsedPath,
+      smoothedParsedPath,
       pointWidth,
       area,
       path,
+      smoothedPath,
       width,
       height,
       pathWidth,
@@ -111,9 +133,11 @@ export function LineChart({
     [
       yGutter,
       parsedPath,
+      smoothedParsedPath,
       pointWidth,
       area,
       path,
+      smoothedPath,
       width,
       height,
       pathWidth,

--- a/src/charts/line/Chart.tsx
+++ b/src/charts/line/Chart.tsx
@@ -5,7 +5,7 @@ import { Dimensions, StyleSheet, View, ViewProps } from 'react-native';
 import { LineChartContext } from './Context';
 import { LineChartIdProvider, useLineChartData } from './Data';
 
-import { getArea, getPath } from './utils';
+import {getArea, getPath, smoothData} from './utils';
 import { parse, Path } from 'react-native-redash';
 
 export const LineChartDimensionsContext = React.createContext({
@@ -33,6 +33,7 @@ type LineChartProps = ViewProps & {
    */
   id?: string;
   absolute?: boolean;
+  smoothDataRadius?: number;
 };
 
 const { width: screenWidth } = Dimensions.get('window');
@@ -47,6 +48,7 @@ export function LineChart({
   shape = d3Shape.curveBumpX,
   id,
   absolute,
+  smoothDataRadius,
   ...props
 }: LineChartProps) {
   const { yDomain, xLength, xDomain } = React.useContext(LineChartContext);
@@ -80,8 +82,9 @@ export function LineChart({
 
   const smoothedPath = React.useMemo(() => {
     if (data && data.length > 0) {
+      const radius = smoothDataRadius ? smoothDataRadius : 2;
       return getPath({
-        data,
+        data: smoothData(data, radius),
         width: pathWidth,
         height,
         gutter: yGutter,
@@ -92,7 +95,16 @@ export function LineChart({
       });
     }
     return '';
-  }, [data, pathWidth, height, yGutter, shape, yDomain, xDomain]);
+  }, [
+    data,
+    smoothDataRadius,
+    pathWidth,
+    height,
+    yGutter,
+    shape,
+    yDomain,
+    xDomain,
+  ]);
 
   const area = React.useMemo(() => {
     if (data && data.length > 0) {

--- a/src/charts/line/types.ts
+++ b/src/charts/line/types.ts
@@ -3,6 +3,7 @@ import type Animated from 'react-native-reanimated';
 export type TLineChartPoint = {
   timestamp: number;
   value: number;
+  smoothedValue: number;
 };
 export type TLineChartDataProp =
   | TLineChartData

--- a/src/charts/line/utils/getPath.ts
+++ b/src/charts/line/utils/getPath.ts
@@ -15,6 +15,7 @@ export function getPath({
   shape: _shape,
   yDomain,
   xDomain,
+  isOriginalData,
 }: {
   data: TLineChartData;
   from?: number;
@@ -25,6 +26,7 @@ export function getPath({
   shape?: unknown;
   yDomain: YDomain;
   xDomain?: [number, number];
+  isOriginalData: boolean;
 }): string {
   const timestamps = data.map(({ timestamp }, i) => (xDomain ? timestamp : i));
 
@@ -44,7 +46,7 @@ export function getPath({
         : true
     )
     .x((_: unknown, i: number) => scaleX(xDomain ? timestamps[i] : i))
-    .y((d: { value: number }) => scaleY(d.value))
+    .y((d: { value: number, smoothedValue: number }) => scaleY(isOriginalData ? d.value : d.smoothedValue))
     .curve(_shape)(data);
   return path;
 }

--- a/src/charts/line/utils/index.ts
+++ b/src/charts/line/utils/index.ts
@@ -3,3 +3,4 @@ export * from './getDomain';
 export * from './getPath';
 export * from './interpolatePath';
 export * from './lineChartDataPropToArray';
+export * from './smoothData';

--- a/src/charts/line/utils/smoothData.ts
+++ b/src/charts/line/utils/smoothData.ts
@@ -1,0 +1,12 @@
+// @ts-ignore
+import smoothish from 'smoothish';
+import type { TLineChartData, TLineChartPoint } from '../types';
+
+export const smoothData = (data: TLineChartData, radius: number) => {
+  let values = data.map((item: TLineChartPoint) => item.value);
+  const smoothed = smoothish(values, { radius: radius });
+  data.forEach(function (item: TLineChartPoint, i: number) {
+    item.smoothedValue = smoothed[i];
+  });
+  return data;
+};


### PR DESCRIPTION
In the previous implementation we were forcing re-rendering to make the smooth effect. The fact is, we don't need to smooth all the chart component it self, we just need to control the SVG Path element created by the data points. 
Inside of the library, there’s a variable for checking if user is playing with the chart or not, it's called (isActive) from `useLineChart() `hook. Based on that, we strategy implemented was: 

- Once the chart library received the data, we create not only the original path element  but also the smoothedPath. 
- Inside of the component that draws the path (src/charts/line/useAnimatedPath.ts ) we use a shared value and `useAnimatedReaction` in order to decide which one should be show. If there's user interaction, then show original path, if it's not show the smoothed data.
- Also all the smooth algorithm to calculated the new data points were moved from StockpileMobile to here. 

This protect us from many problems as heavy render, props computation and the main one to have to work with different data set and manage the interactions accessing both at same time, in order to show the correct values. 